### PR TITLE
since this is for dedicated pi not running RetroPie

### DIFF
--- a/system/autostart.sh
+++ b/system/autostart.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # startup script for a dedicated Pi for Pixelcade that is not running RetroPie, systemd calls this via /etc/systemd/system/pixelcade.service
 PIXELHOME=$HOME/pixelcade
-cd $PIXELHOME && ./pixelweb -image "system/retropie.png" -startup &
+cd $PIXELHOME && ./pixelweb -image "system/pixelcade.png" -startup &


### PR DESCRIPTION
this should show the default image as Pixelcade