### PR TITLE
Update Linux Script to Detect Regardless of Case

### DIFF
--- a/install-scripts/setup-retropie.sh
+++ b/install-scripts/setup-retropie.sh
@@ -50,34 +50,21 @@ echo "Grab a coffee or tea as this installer will take between 10 and 20 minutes
 INSTALLPATH=$HOME"/"
 
 # let's see what installation we have
-if lsb_release -a | grep -qi 'stretch'; then
-        echo "${yellow}Linux Stretch Detected${white}"
-        stretch_os=true
-        echo "Installing curl..."
-        sudo apt install -y curl
-elif cat /etc/os-release | grep -qi 'stretch'; then
-       echo "${yellow}Linux Stretch Detected${white}"
-       stretch_os=true
-       echo "Installing curl..."
-       sudo apt install -y curl
-elif cat /etc/os-release | grep -qi 'jessie'; then
+if lsb_release -a 2>/dev/null | grep -qi 'stretch' || cat /etc/os-release | grep -qi 'stretch'; then
+      echo "${yellow}Linux Stretch Detected${white}"
+      stretch_os=true
+elif lsb_release -a 2>/dev/null | grep -qi 'jessie' || cat /etc/os-release | grep -qi 'jessie'; then
       echo "${yellow}Linux Jessie Detected${white}"
       jessie_os=true
-      echo "Installing curl..."
-      sudo apt install -y curl
-elif lsb_release -a | grep -qi 'buster'; then
+elif lsb_release -a 2>/dev/null | grep -qi 'buster' || cat /etc/os-release | grep -qi 'buster'; then
       echo "${yellow}Linux Buster Detected${white}"
       buster_os=true
-      echo "Installing curl..."
-      sudo apt install -y curl
-elif cat /etc/os-release | grep -qi 'buster'; then
-      echo "${yellow}Linux Buster Detected${white}"
-      buster_os=true
-      echo "Installing curl..."
-      sudo apt install -y curl
-elif lsb_release -a | grep -qi 'ubuntu'; then
+elif lsb_release -a 2>/dev/null | grep -qi 'ubuntu' || cat /etc/os-release | grep -qi 'ubuntu'; then
       echo "${yellow}Ubuntu Linux Detected${white}"
       ubuntu_os=true
+fi
+
+if ! command -v curl &>/dev/null; then
       echo "Installing curl..."
       sudo apt install -y curl
 fi

--- a/install-scripts/setup-retropie.sh
+++ b/install-scripts/setup-retropie.sh
@@ -50,32 +50,32 @@ echo "Grab a coffee or tea as this installer will take between 10 and 20 minutes
 INSTALLPATH=$HOME"/"
 
 # let's see what installation we have
-if lsb_release -a | grep -q 'stretch'; then
+if lsb_release -a | grep -qi 'stretch'; then
         echo "${yellow}Linux Stretch Detected${white}"
         stretch_os=true
         echo "Installing curl..."
         sudo apt install -y curl
-elif cat /etc/os-release | grep -q 'stretch'; then
+elif cat /etc/os-release | grep -qi 'stretch'; then
        echo "${yellow}Linux Stretch Detected${white}"
        stretch_os=true
        echo "Installing curl..."
        sudo apt install -y curl
-elif cat /etc/os-release | grep -q 'jessie'; then
+elif cat /etc/os-release | grep -qi 'jessie'; then
       echo "${yellow}Linux Jessie Detected${white}"
       jessie_os=true
       echo "Installing curl..."
       sudo apt install -y curl
-elif lsb_release -a | grep -q 'buster'; then
+elif lsb_release -a | grep -qi 'buster'; then
       echo "${yellow}Linux Buster Detected${white}"
       buster_os=true
       echo "Installing curl..."
       sudo apt install -y curl
-elif cat /etc/os-release | grep -q 'buster'; then
+elif cat /etc/os-release | grep -qi 'buster'; then
       echo "${yellow}Linux Buster Detected${white}"
       buster_os=true
       echo "Installing curl..."
       sudo apt install -y curl
-elif lsb_release -a | grep -q 'ubuntu'; then
+elif lsb_release -a | grep -qi 'ubuntu'; then
       echo "${yellow}Ubuntu Linux Detected${white}"
       ubuntu_os=true
       echo "Installing curl..."


### PR DESCRIPTION
This pull request makes a minor but important update to the OS detection logic in the `install-scripts/setup-retropie.sh` script. The change ensures that the script correctly identifies supported Linux distributions regardless of the capitalization used in their names.

- Improved OS detection:
  * All `grep -q` commands used for detecting distribution names (`stretch`, `jessie`, `buster`, `ubuntu`) now use the `-i` flag for case-insensitive matching, making the detection more robust.